### PR TITLE
Antiorz

### DIFF
--- a/run.py
+++ b/run.py
@@ -172,7 +172,7 @@ class MyClient(discord.Client):
                     await react_juicy(self, message)
                 if 'wtmoo' in content.lower():
                     await react_wtmoo(self, message)
-                if content.lower().count('orz') > content.lower().count('antiorz'):
+                if content.lower().count('orz') >= content.lower().count('antiorz'):
                     await react_orz(self, message)
                 if 'egg' in content.lower():
                     await react_egg(self, message)

--- a/run.py
+++ b/run.py
@@ -172,7 +172,7 @@ class MyClient(discord.Client):
                     await react_juicy(self, message)
                 if 'wtmoo' in content.lower():
                     await react_wtmoo(self, message)
-                if ('orz' in content.lower()) and not ('antiorz' in content.lower()):
+                if content.lower().count('orz') > content.lower().count('antiorz'):
                     await react_orz(self, message)
                 if 'egg' in content.lower():
                     await react_egg(self, message)

--- a/run.py
+++ b/run.py
@@ -172,7 +172,7 @@ class MyClient(discord.Client):
                     await react_juicy(self, message)
                 if 'wtmoo' in content.lower():
                     await react_wtmoo(self, message)
-                if content.lower().count('orz') >= content.lower().count('antiorz'):
+                if content.lower().count('orz') > content.lower().count('antiorz'):
                     await react_orz(self, message)
                 if 'egg' in content.lower():
                     await react_egg(self, message)

--- a/run.py
+++ b/run.py
@@ -172,7 +172,7 @@ class MyClient(discord.Client):
                     await react_juicy(self, message)
                 if 'wtmoo' in content.lower():
                     await react_wtmoo(self, message)
-                if 'orz' in content.lower():
+                if ('orz' in content.lower()) and not ('antiorz' in content.lower()):
                     await react_orz(self, message)
                 if 'egg' in content.lower():
                     await react_egg(self, message)


### PR DESCRIPTION
Basically orz has spawned the new "antiorz" slang for anti-orz things, however orz bot still reacts to them with orz.

This is very antiorz.

make orz bot orz again
ORZ2020


*its literally a one liner change*

```python
- if 'orz' in content.lower():
+ if ('orz' in content.lower()) and not ('antiorz' in content.lower()):
```

Example:
![image](https://user-images.githubusercontent.com/19739712/107864276-80d5eb80-6e0f-11eb-8769-901ef5f1a8b8.png)


With Patch: (ignore edit message lol)
![image](https://user-images.githubusercontent.com/19739712/107864286-9b0fc980-6e0f-11eb-800c-5a1919804670.png)